### PR TITLE
New parameter for ipt/scan, ipt/scan working with changed auth framework

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/IptController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/IptController.groovy
@@ -20,17 +20,19 @@ class IptController {
      *    <dd> If set to true, then any previously unknown datasets have a data resource created and any existing datasets are updates.</dd>
      *    <dt>check (true)</dt>
      *    <dd>If set to true then only report data resources that need updating</dd>
+     *    <dt>key (catalogNumber)</dt>
+     *    <dd>The term that is used as a key when </dd>
      * <dt>
      * <p>
      * Output formats are JSON, XML or plain text (the default). Plain text is a list of updatable data resource ids
      * suitable for feeding into a shell script.
      */
     def scan() {
-        ActivityLog.log authService.username(), authService.isAdmin(), (String) params.uid, Action.SCAN
         def create = params.create != null && params.create.equalsIgnoreCase("true")
         def check = params.check == null || !params.check.equalsIgnoreCase("false")
+        def keyName = params.key ?: 'catalogNumber'
         def provider = ProviderGroup._get(params.uid)
-        if (create && !authService.isAuthorisedToEdit(params.uid)) {
+        if (create && !authService.userInRole(ProviderGroup.ROLE_ADMIN)) {
             render (status: 403, text: "Unable to create resources for " + params.uid)
             return
         }
@@ -38,7 +40,7 @@ class IptController {
             render (status: 400, text: "Unable to get data provider " + params.uid)
             return
         }
-        def updates = provider == null ? null : iptService.scan(provider, create, check)
+        def updates = provider == null ? null : iptService.scan(provider, create, check, keyName)
         log.info "${updates.size()} data resources to update for ${params.uid}"
         response.addHeader HttpHeaders.VARY, HttpHeaders.ACCEPT
         withFormat {


### PR DESCRIPTION
It turns out that it was already setting a catalogNumber unique key. However, it's worth making it a little more flexible. Added new parameter to allow other termsForUniqueKey than catalogNumber (defaults to catalogNumber)

The authService has changed interface during the move to the plugin. Changed so working with plugin authentication framework