### PR TITLE
Extend EML rendering to include complete rights information

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -490,6 +490,7 @@ dataResource.dataProvider.label=Data provider
 
 institution.dataProvider.label=Institution
 
+proividerGroup.attributions.label=Attributions
 providerGroup.isALAPartner.label=Is ALA Partner
 providerGroup.networkMembership.label=Belongs to
 providerGroup.websiteUrl.label=Website Url
@@ -1726,7 +1727,7 @@ datasets.js.facets09=Institution
 datasets.js.facets10=The organisation or institution that is the source or custodian of the data set
 
 #provider.group.controller.01=你没有被授权访问此页. 你不具有 '收集编辑' 权限.
-#provider.group.controller.02=另一用户已经修改了这个
+#provider.group.cntroller.02=另一用户已经修改了这个
 #provider.group.controller.03=当你在编辑时. 本页已被当前值刷新.
 #provider.group.controller.04=你没有被授权访问此页.
 ##provider.group.controller.05=输入名字

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -490,7 +490,7 @@ dataResource.dataProvider.label=Data provider
 
 institution.dataProvider.label=Institution
 
-proividerGroup.attributions.label=Attributions
+providerGroup.attributions.label=Attributions
 providerGroup.isALAPartner.label=Is ALA Partner
 providerGroup.networkMembership.label=Belongs to
 providerGroup.websiteUrl.label=Website Url
@@ -1727,7 +1727,7 @@ datasets.js.facets09=Institution
 datasets.js.facets10=The organisation or institution that is the source or custodian of the data set
 
 #provider.group.controller.01=你没有被授权访问此页. 你不具有 '收集编辑' 权限.
-#provider.group.cntroller.02=另一用户已经修改了这个
+#provider.group.controller.02=另一用户已经修改了这个
 #provider.group.controller.03=当你在编辑时. 本页已被当前值刷新.
 #provider.group.controller.04=你没有被授权访问此页.
 ##provider.group.controller.05=输入名字

--- a/grails-app/services/au/org/ala/collectory/EmlRenderService.groovy
+++ b/grails-app/services/au/org/ala/collectory/EmlRenderService.groovy
@@ -23,6 +23,7 @@ import java.text.DateFormat
 class EmlRenderService {
 
     static transactional = true
+    def messageSource
     def grailsApplication
     def ns = [eml:"eml://ecoinformatics.org/eml-2.1.1",
             xsi:"http://www.w3.org/2001/XMLSchema-instance",
@@ -470,8 +471,26 @@ class EmlRenderService {
 
                     /* intellectual rights */
                     intellectualRights {
-                        para  pg.rights
-                    }
+                        if (pg.rights) {
+                            section {
+                                title messageSource.getMessage("dataResource.rights.label", null, "Rights", null)
+                                para pg.rights
+                            }
+                        }
+                        if (pg.citation) {
+                            section {
+                                title messageSource.getMessage("dataResource.citation.label", null, "Citation", null)
+                                para pg.citation
+                            }
+                        }
+                        if (pg.licenseType && pg.licenseType != "other") {
+                            section {
+                                def licence = DataResource.ccDisplayList.find({ it.type == pg.licenseType})?.display ?: pg.licenseType
+                                title messageSource.getMessage("dataResource.license.label", null, "License", null)
+                                para pg.licenseVersion != null ? "${licence} ${pg.licenseVersion}" : licence
+                            }
+                        }
+                     }
 
                     /* distribution */
                     distribution {

--- a/test/unit/au/org/ala/collectory/EmlRenderServiceTests.groovy
+++ b/test/unit/au/org/ala/collectory/EmlRenderServiceTests.groovy
@@ -1,22 +1,143 @@
 package au.org.ala.collectory
 
-import grails.test.*
+import grails.test.mixin.*
+import grails.test.mixin.web.ControllerUnitTestMixin
+import org.codehaus.groovy.grails.commons.ConfigurationHolder
+import org.springframework.context.MessageSource
+import spock.lang.Specification
 
-class EmlRenderServiceTests extends GrailsUnitTestCase {
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+
+@TestFor(EmlRenderService)
+@TestMixin(ControllerUnitTestMixin)
+@Mock([DataLink, Attribution, ContactFor])
+class EmlRenderServiceTests extends Specification {
+    static ORGANIZATION1 = "ALA"
+    static ID1 = 2000
+    static GUID1 = 'urn:x-test:tdr100'
+    static UID1 = 'tdr100'
+    static NAME1 = 'Test data resource'
+    static ACRONYM1 = 'TDR'
+    static PUBDESC1 = 'A public description'
+    static TECHDESC1 = 'A technical description'
+    static FOCUS1 = 'Focus'
+    static STATE1 = 'Victoria'
+    static ADDRESS1 = new Address(street: '101 Collins St', city: 'Melbourne', state: STATE1, postcode: '3000')
+    static LATITUDE1 = -35.55
+    static LONGITUDE1 = 148.66
+    static ALTITUDE1 = '100m'
+    static WEBSITEURL1 = 'http://localhost:8080/test'
+    static EMAIL1 = 'nobody@localhost'
+    static PHONE1 = '(99) 8888 7777'
+    static NOTES1 = 'Some notes'
+    static ATTRIBUTIONS1 = 'co100 co101'
+    static RIGHTS1 = 'Copyright CSIRO 2015'
+    static CITATION1 = 'Some random person 2015'
+    static LICENCETYPE1 = DataResource.creativeCommonsLicenses[0]
+    static LICENCEVERSION1 = '3.0'
+    static LASTUPDATED1 = new Date(100000000)
 
     def service = new EmlRenderService()
+    def dr
 
-    protected void setUp() {
-        super.setUp()
+    protected void setup() {
+        grailsApplication.config.eml.organizationName = "Atlas of Living Australia (ALA)"
+        grailsApplication.config.eml.deliveryPoint = "CSIRO Black Mountain Laboratories, Clunies Ross Street, ACTON"
+        grailsApplication.config.eml.city = "Canberra"
+        grailsApplication.config.eml.administrativeArea = "ACT"
+        grailsApplication.config.eml.postalCode = "2601"
+        grailsApplication.config.eml.country = "Australia"
+        grailsApplication.config.eml.electronicMailAddress = "info@ala.org.au"
+        service.grailsApplication = grailsApplication
+        service.messageSource = Mock(MessageSource)
+        service.messageSource.getMessage(_, _, _, _) >> { code, args, deflt, locale -> deflt }
+        dr = new DataResource(
+                guid: GUID1,
+                uid: UID1,
+                name: NAME1,
+                acronym: ACRONYM1,
+                pubDescription: PUBDESC1,
+                techDescription: TECHDESC1,
+                focus: FOCUS1,
+                address: ADDRESS1,
+                latitude: LATITUDE1,
+                longitude: LONGITUDE1,
+                altitude: ALTITUDE1,
+                state: STATE1,
+                websiteUrl: WEBSITEURL1,
+                email: EMAIL1,
+                phone: PHONE1,
+                notes: NOTES1,
+                attributions: ATTRIBUTIONS1,
+                rights: RIGHTS1,
+                citation: CITATION1,
+                licenseType: LICENCETYPE1,
+                licenseVersion: LICENCEVERSION1
+        )
+        dr.id = ID1
+        dr.lastUpdated = LASTUPDATED1
     }
 
-    protected void tearDown() {
-        super.tearDown()
+    void testDataResource1() {
+        when:
+        String emls = service.emlForResource(dr)
+        XmlSlurper slurper = new XmlSlurper()
+        def eml = slurper.parse(new StringReader(emls))
+        println emls
+        then:
+        eml != null
+        def dataset = eml.dataset
+        dataset.alternateIdentifier?.find({it == "org.ala.au:${UID1}"}) != null
+        dataset.title == NAME1
+        dataset.pubDate == (new SimpleDateFormat('EEE MMM dd')).format(LASTUPDATED1)
+        dataset.abstract?.para == "${PUBDESC1}\n${TECHDESC1}"
+        dataset.creator != null
+        dataset.creator.organizationName == NAME1
+        dataset.creator.address != null
+        dataset.creator.address.deliveryPoint == ADDRESS1.street
+        dataset.creator.phone == PHONE1
+        dataset.creator.electronicMailAddress.text() == EMAIL1
+        dataset.creator.onlineUrl == WEBSITEURL1
+        dataset.intellectualRights != null
+        dataset.intellectualRights.section.size() == 3
+        dataset.intellectualRights.section[0].title == "Rights"
+        dataset.intellectualRights.section[0].para == RIGHTS1
+        dataset.intellectualRights.section[1].title == "Citation"
+        dataset.intellectualRights.section[1].para == CITATION1
+        dataset.intellectualRights.section[2].title == "License"
+        dataset.intellectualRights.section[2].para == "Creative Commons Attribution 3.0"
+        dataset.contact?.organizationName == grailsApplication.config.eml.organizationName
     }
 
-    void testService() {
-        String eml = service.emlForResource()
-        println eml
-        assertNotNull eml
+
+    void testDataResource2() {
+        when:
+        dr.rights = null
+        dr.licenseType = 'other'
+        dr.licenseVersion = null
+        String emls = service.emlForResource(dr)
+        XmlSlurper slurper = new XmlSlurper()
+        def eml = slurper.parse(new StringReader(emls))
+        then:
+        eml != null
+        def dataset = eml.dataset
+        dataset.alternateIdentifier?.find({it == "org.ala.au:${UID1}"}) != null
+        dataset.title == NAME1
+        dataset.pubDate == (new SimpleDateFormat('EEE MMM dd')).format(LASTUPDATED1)
+        dataset.abstract?.para == "${PUBDESC1}\n${TECHDESC1}"
+        dataset.creator != null
+        dataset.creator.organizationName == NAME1
+        dataset.creator.address != null
+        dataset.creator.address.deliveryPoint == ADDRESS1.street
+        dataset.creator.phone == PHONE1
+        dataset.creator.electronicMailAddress == EMAIL1
+        dataset.creator.onlineUrl == WEBSITEURL1
+        dataset.intellectualRights != null
+        dataset.intellectualRights.section.size() == 1
+        dataset.intellectualRights.section[0].title == "Citation"
+        dataset.intellectualRights.section[0].para == CITATION1
+        dataset.contact?.organizationName == grailsApplication.config.eml.organizationName
     }
+
 }


### PR DESCRIPTION
intellectualRights now contains several sections that give rights information. See https://github.com/AtlasOfLivingAustralia/collectory-plugin/issues/31 for example output.