### PR TITLE
update dataresource downloaded from gbif

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/ManageController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/ManageController.groovy
@@ -59,6 +59,45 @@ class ManageController {
 
     /**
      *
+     * @return
+     */
+    def loadDataset() {
+        log.debug("Loading resources from GBIF: " + params)
+        if (params.guid && params.gbifUsername && params.gbifPassword) {
+            gbifService.getGbifDataset(
+                    params.guid,
+                    params.gbifUsername,
+                    params.gbifPassword)
+            redirect(action: 'gbifDatasetLoadStatus', model: ['datasetKey': params.guid], params: ['datasetKey': params.guid])
+        }
+    }
+
+    /**
+     *
+     * Display the load status for the supplied country
+     * country - the country to supply the status for
+     * @return
+     */
+    def gbifDatasetLoadStatus(){
+        log.debug('key->'+params.datasetKey)
+        def gbifSummary = gbifService.getDatasetKeyStatusInfoFor(params.datasetKey)
+        log.debug(gbifSummary)
+        [gbifSummary:gbifSummary,'datasetKey':params.datasetKey]
+    }
+
+
+    /**
+     *
+     * @return
+     */
+    def gbifDatasetDownload() {
+        log.debug('Dataset id ' + params.id)
+        def dr = DataResource.findByUid(params.id)
+        render(view: "gbifDatasetDownload", model: ['uid': dr.uid, 'guid' : dr.guid])
+    }
+
+    /**
+     *
      * Display the load status for the supplied country
      * country - the country to supply the status for
      * @return

--- a/grails-app/domain/au/org/ala/collectory/DataResource.groovy
+++ b/grails-app/domain/au/org/ala/collectory/DataResource.groovy
@@ -42,8 +42,10 @@ class DataResource extends ProviderGroup implements Serializable {
     boolean riskAssessment = false  // has risk assessment been done (for Data Provider Agreements only)
     boolean filed = false           // has the document been filed (for Data Provider Agreements only)
     String status = "identified"    // integration status (of the integration of the resource into the atlas)
+    boolean gbifDataSet = false
     String harvestingNotes          // may include which components (text, images, etc) can be harvested
     String mobilisationNotes        //
+
     int harvestFrequency = 0
     Timestamp lastChecked           // when the last check was made for new data
     Timestamp dataCurrency          // the date of production of the most recent data file
@@ -255,4 +257,5 @@ class DataResource extends ProviderGroup implements Serializable {
     String shortProviderName() {
         return shortProviderName(30)
     }
+
 }

--- a/grails-app/domain/au/org/ala/collectory/DataResource.groovy
+++ b/grails-app/domain/au/org/ala/collectory/DataResource.groovy
@@ -44,7 +44,6 @@ class DataResource extends ProviderGroup implements Serializable {
     String status = "identified"    // integration status (of the integration of the resource into the atlas)
     String harvestingNotes          // may include which components (text, images, etc) can be harvested
     String mobilisationNotes        //
-
     int harvestFrequency = 0
     Timestamp lastChecked           // when the last check was made for new data
     Timestamp dataCurrency          // the date of production of the most recent data file
@@ -256,5 +255,5 @@ class DataResource extends ProviderGroup implements Serializable {
     String shortProviderName() {
         return shortProviderName(30)
     }
-
 }
+

--- a/grails-app/domain/au/org/ala/collectory/DataResource.groovy
+++ b/grails-app/domain/au/org/ala/collectory/DataResource.groovy
@@ -256,4 +256,3 @@ class DataResource extends ProviderGroup implements Serializable {
         return shortProviderName(30)
     }
 }
-

--- a/grails-app/domain/au/org/ala/collectory/DataResource.groovy
+++ b/grails-app/domain/au/org/ala/collectory/DataResource.groovy
@@ -42,7 +42,6 @@ class DataResource extends ProviderGroup implements Serializable {
     boolean riskAssessment = false  // has risk assessment been done (for Data Provider Agreements only)
     boolean filed = false           // has the document been filed (for Data Provider Agreements only)
     String status = "identified"    // integration status (of the integration of the resource into the atlas)
-    boolean gbifDataSet = false
     String harvestingNotes          // may include which components (text, images, etc) can be harvested
     String mobilisationNotes        //
 

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1187,6 +1187,7 @@ manage.gbifdldataset.des05=This is a simple method of bootstrapping an installat
 manage.gbifdldataset.des06=This is not intended for long-term production use
 
 manage.gbifdds.title=Downloading dataset
+manage.gbifdds.returnToDataResource=Back to {0}
 
 providerCode.label=ProviderCode
 

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1178,7 +1178,6 @@ manage.gbifdldataset.title01=Automatically load resources from GBIF based on a s
 manage.gbifdldataset.label01=Dataset key
 manage.gbifdldataset.label02=GBIF username
 manage.gbifdldataset.label03=GBIF password
-manage.gbifdldataset.label04=Maximum resources (will default to all)
 manage.gbifdldataset.des01=This tool will download archives from GBIF web services, store the archives locally and create an initial metadata record for each resource
 manage.gbifdldataset.des02=This will not load the data into the occurrence store automatically
 manage.gbifdldataset.des03=To obtain a username, please register with the GBIF web site

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -1173,6 +1173,21 @@ manage.gbifcls.th.link=Link (will appear when download complete)
 manage.gbifcls.title04=No resources available to load for
 manage.gbifcls.title05=To try again click
 manage.gbifcls.link01=here
+manage.gbifdldataset.title=Load GBIF Resources {0}
+manage.gbifdldataset.title01=Automatically load resources from GBIF based on a supplied country
+manage.gbifdldataset.label01=Dataset key
+manage.gbifdldataset.label02=GBIF username
+manage.gbifdldataset.label03=GBIF password
+manage.gbifdldataset.label04=Maximum resources (will default to all)
+manage.gbifdldataset.des01=This tool will download archives from GBIF web services, store the archives locally and create an initial metadata record for each resource
+manage.gbifdldataset.des02=This will not load the data into the occurrence store automatically
+manage.gbifdldataset.des03=To obtain a username, please register with the GBIF web site
+manage.gbifdldataset.link01=here
+manage.gbifdldataset.des04=Note
+manage.gbifdldataset.des05=This is a simple method of bootstrapping an installation with data provided by GBIF web services
+manage.gbifdldataset.des06=This is not intended for long-term production use
+
+manage.gbifdds.title=Downloading dataset
 
 providerCode.label=ProviderCode
 

--- a/grails-app/services/au/org/ala/collectory/GbifService.groovy
+++ b/grails-app/services/au/org/ala/collectory/GbifService.groovy
@@ -348,7 +348,7 @@ class GbifService {
             //move the DwCA where it needs to be
             def connParams = (new JsonSlurper()).parseText(dr.connectionParameters?:'{}')
             connParams.url = 'file:///'+targetFileName
-            connParams.protocol = "GBIF"
+            connParams.protocol = "DwCA"
             connParams.termsForUniqueKey = ["gbifID"]
             //NQ we need a transaction so the this can be executed in a multi-threaded manner.
             DataResource.withTransaction {

--- a/grails-app/views/dataResource/show.gsp
+++ b/grails-app/views/dataResource/show.gsp
@@ -186,6 +186,9 @@
                 <cl:ifGranted role="${ProviderGroup.ROLE_ADMIN}">
                   <div><span class="buttons"><g:link class="edit btn" action='edit' params="[page:'contribution']" id="${instance.uid}">${message(code: 'default.button.edit.label', default: 'Edit')}</g:link></span></div>
                 </cl:ifGranted>
+                <cl:ifGranted role="${ProviderGroup.ROLE_EDITOR}">
+                    <div><span class="buttons"><g:link class="edit btn" controller="manage" action="gbifDatasetDownload" id="${instance.uid}">${message(code: 'datasource.button.update', default: 'Update')}</g:link></span></div>
+                </cl:ifGranted>
               </div>
 
               <div class="well">

--- a/grails-app/views/manage/gbifDatasetDownload.gsp
+++ b/grails-app/views/manage/gbifDatasetDownload.gsp
@@ -12,7 +12,7 @@
     <div class="span5">
         <table>
             <tr class="prop">
-                <td valign="top" class="name"><label for="guid"><g:message code="manage.gbifdldataset.label02" />:</label></td>
+                <td valign="top" class="name"><label for="guid"><g:message code="manage.gbifdldataset.label01" />:</label></td>
                 <td valign="top" class="value"><g:field type="text" name="guid" required="true" value="${guid}" readonly="true" /></td>
             </tr>
             <tr class="prop">

--- a/grails-app/views/manage/gbifDatasetDownload.gsp
+++ b/grails-app/views/manage/gbifDatasetDownload.gsp
@@ -1,0 +1,49 @@
+<%@ page import="grails.converters.JSON; au.org.ala.collectory.ProviderGroup; au.org.ala.collectory.DataProvider" %>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="layout" content="${grailsApplication.config.skin.layout}" />
+    <title><g:message code="manage.gbiflc.title" /></title>
+</head>
+<body>
+<h1><g:message code="manage.gbifdldataset.title01" /></h1>
+<div id="baseForm">
+<g:form action="loadDataset" controller="manage">
+    <div class="span5">
+        <table>
+            <tr class="prop">
+                <td valign="top" class="name"><label for="guid"><g:message code="manage.gbifdldataset.label02" />:</label></td>
+                <td valign="top" class="value"><g:field type="text" name="guid" required="true" value="${guid}" readonly="true" /></td>
+            </tr>
+            <tr class="prop">
+                <td valign="top" class="name"><label for="gbifUsername"><g:message code="manage.gbifdldataset.label02" />:</label></td>
+                <td valign="top" class="value"><g:field type="text" name="gbifUsername" required="true" value="" /></td>
+            </tr>
+            <tr class="prop">
+                <td valign="top" class="name"><label for="gbifPassword"><g:message code="manage.gbifdldataset.label03" />:</label> </td>
+                <td valign="top" class="value"><g:field type="password" name="gbifPassword" required="true" value="" /></td>
+            </tr>
+        </table>
+        <span class="button"><input type="submit" name="performGBIFLoad" value="Load" class="save btn"></span>
+    </div>
+
+    <div class="well pull-right span5">
+        <p>
+            <g:message code="manage.gbifdldataset.des01" />.<br/>
+            <g:message code="manage.gbifdldataset.des02" />.
+            <br/>
+            <g:message code="manage.gbifdldataset.des03" />
+            <a href="http://www.gbif.org/user/register"><g:message code="manage.gbifdldataset.link01" /></a>.
+        </p>
+        <p>
+            <b><g:message code="manage.gbifdldataset.des04" /></b>: <g:message code="manage.gbifdldataset.des05" />.<br/>
+            <g:message code="manage.gbifdldataset.des06" />.
+        </p>
+    </div>
+    </div>
+
+</g:form>
+</div>
+
+</body>
+</html>

--- a/grails-app/views/manage/gbifDatasetLoadStatus.gsp
+++ b/grails-app/views/manage/gbifDatasetLoadStatus.gsp
@@ -29,12 +29,9 @@
 <body>
 <g:if test="${gbifSummary}">
     <h1>${gbifSummary.gbifResourceUid} - ${gbifSummary.phase}</h1>
+    <g:if test="${gbifSummary.isComplete()}">
+        <g:link controller="dataResource" action="show" id="${gbifSummary.dataResourceUid}"><g:message code="manage.gbifdds.returnToDataResource" args="${[gbifSummary.dataResourceUid]}"></g:message></g:link>
+    </g:if>
 </g:if>
-<g:else>
-    <h1><g:message code="manage.gbifdds.title04" /> ${datasetKey}</h1>
-    <p>
-        <g:message code="manage.gbifdds.title05" /> <g:link controller="manage" action="gbifDatasetDownload" id=""> <g:message code="manage.gbifdds.link01" />.</g:link>
-    </p>
-</g:else>
 </body>
 </html>

--- a/grails-app/views/manage/gbifDatasetLoadStatus.gsp
+++ b/grails-app/views/manage/gbifDatasetLoadStatus.gsp
@@ -1,0 +1,40 @@
+
+<%@ page import="grails.converters.JSON; au.org.ala.collectory.ProviderGroup; au.org.ala.collectory.DataProvider" %>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="layout" content="${grailsApplication.config.skin.layout}" />
+    %{--TODO At the moment this is performing a complete reload every 15 seconds while the load has not finished. Make this AJAXy--}%
+    <title><g:message code="manage.gbifdds.title" /> ${datasetKey}</title>
+
+    <g:if test="${gbifSummary}">
+        <script type="text/javascript">
+            if (!window.console) console = {log: function() {}};
+            //setup the page
+            $(document).ready(function(){
+                window.setTimeout(refresh, 15000)
+            });
+
+            function refresh() {
+                var isRunning = ${! gbifSummary.isComplete()};
+                if(isRunning){
+                    console.log("Refreshing page...")
+                    window.location.reload(true);
+                    window.setTimeout(refresh, 15000);
+                }
+            }
+        </script>
+    </g:if>
+</head>
+<body>
+<g:if test="${gbifSummary}">
+    <h1>${gbifSummary.gbifResourceUid} - ${gbifSummary.phase}</h1>
+</g:if>
+<g:else>
+    <h1><g:message code="manage.gbifdds.title04" /> ${datasetKey}</h1>
+    <p>
+        <g:message code="manage.gbifdds.title05" /> <g:link controller="manage" action="gbifDatasetDownload" id=""> <g:message code="manage.gbifdds.link01" />.</g:link>
+    </p>
+</g:else>
+</body>
+</html>


### PR DESCRIPTION
This let's you update dataresources downloaded from gbif. 

In order to work you need to set gbif dataset key as data resource GUID.

Click on Update button, use your gbif.org credentials and it downloads the dataset. Once it's completed you have to ingest the resource again.