### PR TITLE
Close CSV report for GBIF

### DIFF
--- a/grails-app/services/au/org/ala/collectory/GbifRegistryService.groovy
+++ b/grails-app/services/au/org/ala/collectory/GbifRegistryService.groovy
@@ -717,6 +717,7 @@ class GbifRegistryService {
                 csvWriter.writeNext(row)
             }
         }
+        csvWriter.close()
     }
 
     /**


### PR DESCRIPTION
Otherwise the file that is downloaded is incomplete, depending what was left in the write buffer.