### PR TITLE
Avoid re-adding existing contacts

### DIFF
--- a/grails-app/services/au/org/ala/collectory/DataImportService.groovy
+++ b/grails-app/services/au/org/ala/collectory/DataImportService.groovy
@@ -164,8 +164,15 @@ class DataImportService {
 
         //add contacts
         if(contacts){
+            def existingContacts = dataResource.getContacts()
             contacts.each { contact ->
+                def isNew = true
+                existingContacts.each {
+                    if (it.contact.email == contact.email) isNew = false
+                }
+                if (isNew) {
                     dataResource.addToContacts(contact, null, false, true, collectoryAuthService.username())
+                }
             }
         }
     }


### PR DESCRIPTION
Possibly this hasn't affected your implementation, but for us every time one re-imports a DWCA with contacts they are added even if they are already in the contact list, leading to duplication.