### PR TITLE
Sync fix for ALA resource stats lookup

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/IptController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/IptController.groovy
@@ -111,7 +111,7 @@ class IptController {
             iptInventory.registeredResources.each { item ->
                 iptMap.put(item.title, item.records)
                 //retrieve UID, and do a count from the services
-                def uid = newMap.get(item.title)
+                def uid = newMap.get(item.title.toLowerCase())
                 if(uid){
                     def jsonCount = new JsonSlurper().parse(new URL(grailsApplication.config.biocacheServicesUrl + "/occurrences/search?pageSize=0&fq=data_resource_uid:" + uid))
                     String[] row = [


### PR DESCRIPTION
When using "Download sync report" we get all Atlas stats to zero.

`IptController` build a map or titles-drIds with lowercase titles but later tries to find some resource using it's title (no lowercase).