### PR TITLE
Fix contactsForEntity WS

### DIFF
--- a/grails-app/controllers/au/org/ala/collectory/DataController.groovy
+++ b/grails-app/controllers/au/org/ala/collectory/DataController.groovy
@@ -740,7 +740,7 @@ class DataController {
                 def out = new StringWriter()
                 out << "name, role, primary contact, editor, notify, email, phone\n"
                 contactList.each {
-                    out << "\"${it.name}\",\"${it.role}\",${it.primaryContact},${it.editor},${it.notify},${it.email?:""},${it.phone?:""}\n"
+                    out << "\"${(it.contact.firstName + ' ' + it.contact.lastName).trim()}\",\"${it.role}\",${it.primaryContact},${it.editor},${it.notify},${it.contact.email?:""},${it.contact.phone?:""}\n"
                 }
                 response.addHeader "Content-Type", "text/csv"
                 render out.toString()


### PR DESCRIPTION
It might be useful to use the CONTACT_HEADER fields, but I didn't want to break anything that relies on the existing structure.

https://collections.ala.org.au/ws/collection/co13/contacts shows the existing bug (name=null, email missing, etc.)