### PR TITLE
Add event as param to click fn to prevent FF add subcollection error

### DIFF
--- a/grails-app/views/collection/description.gsp
+++ b/grails-app/views/collection/description.gsp
@@ -149,7 +149,7 @@
             $(event.target).parent().remove();
         });
 
-        $('#addSubcollection').click(function(){
+        $('#addSubcollection').click(function(event){
 
             event.preventDefault();
             var $subcollection = $('#subcollection_template').clone();


### PR DESCRIPTION
Add subcollections fails in FF with `ReferenceError: event is not defined`. So event should be passed to prevent this error. Add subcollections does not fails in Chrome/chromium. 

Related: https://stackoverflow.com/questions/33167092/why-is-event-variable-available-even-when-not-passed-as-a-parameter
