### PR TITLE
Skip resources with empty eml

### DIFF
--- a/grails-app/services/au/org/ala/collectory/IptService.groovy
+++ b/grails-app/services/au/org/ala/collectory/IptService.groovy
@@ -204,7 +204,7 @@ class IptService {
         resource.isShareableWithGBIF = isShareableWithGBIF
 
         def contacts = []
-        if (eml != null) {
+        if (eml != null && eml != "") {
             contacts = retrieveEml(resource, eml)
         }
 


### PR DESCRIPTION
We have an external IPT with a testing dr with its eml empty. This causes that we cannot sync other valid resources from this data provider. The error:
``` 
2021-03-09 13:02:57,870 ERROR [IptController] Problem scanning IPT endpoint: Target host is null
java.lang.IllegalStateException: Target host is null
        at org.apache.http.util.Asserts.notNull(Asserts.java:46)
        at org.apache.http.impl.conn.DefaultHttpRoutePlanner.determineRoute(DefaultHttpRoutePlanner.java:98)
        at org.apache.http.impl.client.DefaultRequestDirector.determineRoute(DefaultRequestDirector.java:762)
        at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:381)
        at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:863)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:57)
        at groovyx.net.http.HTTPBuilder.doRequest(HTTPBuilder.java:476)
        at groovyx.net.http.HTTPBuilder.get(HTTPBuilder.java:292)
        at groovyx.net.http.HTTPBuilder.get(HTTPBuilder.java:262)
        at au.org.ala.collectory.IptService.retrieveEml(IptService.groovy:225)
``` 

![2021-01-09-13-27-50-screenshot](https://user-images.githubusercontent.com/180085/110484527-05ecb180-80eb-11eb-9229-992f9ecc73b4.png)

This PR adds an extra condition for these cases.